### PR TITLE
Fix bugs in ListClaimsCommand

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ListClaimsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListClaimsCommand.java
@@ -34,7 +34,8 @@ public class ListClaimsCommand extends Command {
     public static final String MESSAGE_LIST_CLAIMS_SUCCESS = "Claims listed for policy type '%1$s' of client: "
             + "%2$s\n\n%3$s";
     public static final String MESSAGE_NO_CLAIMS = "No claims found for policy type '%1$s' of client: %2$s";
-    public static final String MESSAGE_INVALID_CLIENT_INDEX = "The client index provided is invalid.";
+    public static final String MESSAGE_INVALID_CLIENT_INDEX = "The index you provided exceeds the total number of "
+            + "clients you have.\nPlease check the index of the client you are looking for using the 'list' command!";
     public static final String MESSAGE_NO_POLICY_OF_TYPE = "No policy of type '%1$s' found for client: %2$s";
 
     private final Index clientIndex;

--- a/src/main/java/seedu/address/logic/parser/ListClaimsCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListClaimsCommandParser.java
@@ -36,13 +36,10 @@ public class ListClaimsCommandParser implements Parser<ListClaimsCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListClaimsCommand.MESSAGE_USAGE));
         }
 
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_POLICY_TYPE);
+
         PolicyType policyType;
-        try {
-            policyType = ParserUtil.parsePolicyType(argMultimap.getValue(PREFIX_POLICY_TYPE).get());
-        } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListClaimsCommand.MESSAGE_USAGE),
-                    pe);
-        }
+        policyType = ParserUtil.parsePolicyType(argMultimap.getValue(PREFIX_POLICY_TYPE).get());
 
         return new ListClaimsCommand(clientIndex, policyType);
     }


### PR DESCRIPTION
1. Incorrect error message shown when invalid policy type is given.
2. Command did not check for duplicated single field prefixes.
3. Improved user feedback message when index is out of bounds.